### PR TITLE
Update php properties from release php-2025.12.7

### DIFF
--- a/modules/php.properties
+++ b/modules/php.properties
@@ -76,4 +76,3 @@
 7.4.30 = https://github.com/Bearsampp/modules-untouched/releases/download/php-7.4.30/php-7.4.30-Win32-vc15-x64.zip
 5.6.40 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.07.30/php-5.6.40-Win32-VC11-x64.zip
 3.8.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php_imagick-3.8.0-8.5-ts-vs17-x64.zip
-3.5.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php_xdebug-3.5.0-8.5-ts-vs17-x86_64.zip


### PR DESCRIPTION
### **User description**
## 🤖 Automated Module Properties Update

This PR updates the `php.properties` file with new versions from release `php-2025.12.7`.

### Changes:
- Extracted assets starting with `php` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/php-2025.12.7

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs


___

### **PR Type**
Enhancement


___

### **Description**
- Updates PHP module properties from release php-2025.12.7

- Removes outdated xdebug 3.5.0 entry from version list

- Maintains semver ordering with newest versions first


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["php.properties file"] -- "Remove xdebug 3.5.0" --> B["Updated version list"]
  A -- "Maintain semver order" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>php.properties</strong><dd><code>Remove outdated xdebug 3.5.0 version entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/php.properties

<ul><li>Removed xdebug version 3.5.0 entry from the properties file<br> <li> Preserved all other PHP version entries (8.0.x, 7.4.x, 5.6.x, 3.8.0)<br> <li> Maintained semver ordering with newest versions listed first</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/modules-untouched/pull/38/files#diff-bdce73fbe7a01c9b812c610025b2156fb03ea99b4ed5af59c2540f036c589b64">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

