### PR TITLE
Update php properties from release php-2026.1.16

### DIFF
--- a/modules/php.properties
+++ b/modules/php.properties
@@ -80,5 +80,5 @@
 7.4.32 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.09.30/php-7.4.32-Win32-vc15-x64.zip
 7.4.30 = https://github.com/Bearsampp/modules-untouched/releases/download/php-7.4.30/php-7.4.30-Win32-vc15-x64.zip
 5.6.40 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.07.30/php-5.6.40-Win32-VC11-x64.zip
-3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php_imagick-3.8.1-8.5-ts-vs17-x86.zip
+3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php_imagick-3.8.1-8.5-ts-vs17-x86_64.zip
 3.8.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php_imagick-3.8.0-8.5-ts-vs17-x64.zip


### PR DESCRIPTION
### **User description**
## 🤖 Automated Module Properties Update

This PR updates the `php.properties` file with new versions from release `php-2026.1.16`.

### Changes:
- Extracted assets starting with `php` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/php-2026.1.16

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects PHP Imagick 3.8.1 download URL architecture

- Changes x86 to x86_64 in release asset filename


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["php.properties"] -- "Update Imagick 3.8.1 URL" --> B["x86 to x86_64"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>php.properties</strong><dd><code>Fix Imagick 3.8.1 URL architecture suffix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/php.properties

<ul><li>Corrects the download URL for PHP Imagick version 3.8.1<br> <li> Changes architecture suffix from x86 to x86_64 in the release asset <br>filename<br> <li> Ensures correct binary architecture is downloaded for the module</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/modules-untouched/pull/63/files#diff-bdce73fbe7a01c9b812c610025b2156fb03ea99b4ed5af59c2540f036c589b64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

