### PR TITLE
Update php properties from release php-2026.3.4

### DIFF
--- a/module_name.txt
+++ b/module_name.txt
@@ -1,1 +1,1 @@
-ruby
+php

--- a/modules/php.properties
+++ b/modules/php.properties
@@ -1,5 +1,7 @@
+8.5.3 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php-8.5.3-Win32-vs17-x64.zip
 8.5.2 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php-8.5.2-Win32-vs17-x64.zip
 8.5.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php-8.5.0-Win32-vs17-x64.zip
+8.4.18 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php-8.4.18-Win32-vs17-x64.zip
 8.4.17 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php-8.4.17-Win32-vs17-x64.zip
 8.4.15 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php-8.4.15-Win32-vs17-x64.zip
 8.4.14 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.10.31/php-8.4.14-Win32-vs17-x64.zip
@@ -47,7 +49,7 @@
 8.2.3 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2023.3.5/php-8.2.3-Win32-vs16-x64.zip
 8.2.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2023.1.31/php-8.2.1-Win32-vs16-x64.zip
 8.2.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.12.13/php-8.2.0-Win32-vs16-x64.zip
-8.2 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php_memcache-8.2-8.2-ts-vs16-x64.zip
+8.2 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_memcache-8.2-8.5-ts-vs17-x64.zip
 8.1.33 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.8.20/php-8.1.33-Win32-vs16-x64.zip
 8.1.32 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.4.8/php-8.1.32-Win32-vs16-x64.zip
 8.1.31 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2024.11.30/php-8.1.31-Win32-vs16-x64.zip
@@ -80,5 +82,6 @@
 7.4.32 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.09.30/php-7.4.32-Win32-vc15-x64.zip
 7.4.30 = https://github.com/Bearsampp/modules-untouched/releases/download/php-7.4.30/php-7.4.30-Win32-vc15-x64.zip
 5.6.40 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.07.30/php-5.6.40-Win32-VC11-x64.zip
-3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php_imagick-3.8.1-8.5-ts-vs17-x86_64.zip
+3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.8.1-8.5-nts-vs17-x86.zip
 3.8.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php_imagick-3.8.0-8.5-ts-vs17-x64.zip
+3.7.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.7.0-8.4-ts-vs17-x64.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `php.properties` file with new versions from release `php-2026.3.4`.

### Changes:
- Extracted assets starting with `php` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/php-2026.3.4

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs