### PR TITLE
Update php properties from release php-2026.3.4

### DIFF
--- a/modules/php.properties
+++ b/modules/php.properties
@@ -82,6 +82,6 @@
 7.4.32 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.09.30/php-7.4.32-Win32-vc15-x64.zip
 7.4.30 = https://github.com/Bearsampp/modules-untouched/releases/download/php-7.4.30/php-7.4.30-Win32-vc15-x64.zip
 5.6.40 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.07.30/php-5.6.40-Win32-VC11-x64.zip
-3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.8.1-8.5-nts-vs17-x86.zip
+3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.8.1-8.5-ts-vs17-x64.zip
 3.8.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php_imagick-3.8.0-8.5-ts-vs17-x64.zip
 3.7.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.7.0-8.4-ts-vs17-x64.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `php.properties` file with new versions from release `php-2026.3.4`.

### Changes:
- Extracted assets starting with `php` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/php-2026.3.4

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs