### PR TITLE
Update mysql properties from release mysql-2026.3.4

### DIFF
--- a/module_name.txt
+++ b/module_name.txt
@@ -1,1 +1,1 @@
-php
+mysql

--- a/modules/mysql.properties
+++ b/modules/mysql.properties
@@ -1,9 +1,11 @@
+9.6.0 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2026.3.4/mysql-9.6.0-winx64.zip
 9.5.0 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.11.23/mysql-9.5.0-winx64.zip
 9.4.0 = https://github.com/Bearsampp/modules-untouched/releases/download/Mysql-2025.8.21/mysql-9.4.0-winx64.zip
 9.3.0 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.4.18/mysql-9.3.0-winx64.zip
 9.2.0 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.1.23/mysql-9.2.0-winx64.zip
 9.1.0 = https://github.com/Bearsampp/modules-untouched/releases/download/Mysql-2024.12.1/mysql-9.1.0-winx64.zip
 9.0.1 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2024.7.28/mysql-9.0.1-winx64.zip
+8.4.8 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2026.3.4/mysql-8.4.8-winx64.zip
 8.4.7 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.11.23/mysql-8.4.7-winx64.zip
 8.4.6 = https://github.com/Bearsampp/modules-untouched/releases/download/Mysql-2025.8.21/mysql-8.4.6-winx64.zip
 8.4.5 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.4.18/mysql-8.4.5-winx64.zip
@@ -13,6 +15,7 @@
 8.4 = https://github.com/Bearsampp/modules-untouched/releases/download/MySQL-2024.5.9/mysql-8.4.0-winx64.zip
 8.3.0 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2024.4.10/mysql-8.3.0-winx64.zip
 8.1.0 = https://github.com/Bearsampp/modules-untouched/releases/download/Mysql-2023.10.9/mysql-8.1.0-winx64.zip
+8.0.45 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2026.3.4/mysql-8.0.45-winx64.zip
 8.0.44 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.11.23/mysql-8.0.44-winx64.zip
 8.0.42 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.4.18/mysql-8.0.42-winx64.zip
 8.0.41 = https://github.com/Bearsampp/modules-untouched/releases/download/mysql-2025.1.23/mysql-8.0.41-winx64.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `mysql.properties` file with new versions from release `mysql-2026.3.4`.

### Changes:
- Extracted assets starting with `mysql` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/mysql-2026.3.4

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs