### PR TITLE
Update mariadb properties from release Mariadb-2026.3.7

### DIFF
--- a/module_name.txt
+++ b/module_name.txt
@@ -1,1 +1,1 @@
-mailpit
+mariadb

--- a/modules/mariadb.properties
+++ b/modules/mariadb.properties
@@ -1,5 +1,7 @@
+12.2.2 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2026.3.7/mariadb-12.2.2-winx64.zip
 12.1.2 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.11.22/mariadb-12.1.2-winx64.zip
 12.0.2 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2025.8.21/mariadb-12.0.2-winx64.zip
+11.8.6 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2026.3.7/mariadb-11.8.6-winx64.zip
 11.8.5 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.11.22/mariadb-11.8.5-winx64.zip
 11.8.3 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2025.8.21/mariadb-11.8.3-winx64.zip
 11.8.2 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.7.2/mariadb-11.8.2-winx64.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `mariadb.properties` file with new versions from release `Mariadb-2026.3.7`.

### Changes:
- Extracted assets starting with `mariadb` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/Mariadb-2026.3.7

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs