### PR TITLE
Update memcached properties from release memcached-2026.03.07

### DIFF
--- a/module_name.txt
+++ b/module_name.txt
@@ -1,1 +1,1 @@
-mariadb
+memcached

--- a/modules/memcached.properties
+++ b/modules/memcached.properties
@@ -1,3 +1,4 @@
+1.6.41 = https://github.com/Bearsampp/modules-untouched/releases/download/memcached-2026.03.07/memcached-1.6.41.7z
 1.6.40.7 = https://github.com/Bearsampp/modules-untouched/releases/download/Memcached-2026.1.15/memcached-1.6.40.7z
 1.6.39 = https://github.com/Bearsampp/modules-untouched/releases/download/memcached-2025.11.18/memcached-1.6.39.zip
 1.6.38 = https://github.com/Bearsampp/modules-untouched/releases/download/memcached-2025.4.19/memcached-1.6.38.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `memcached.properties` file with new versions from release `memcached-2026.03.07`.

### Changes:
- Extracted assets starting with `memcached` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/memcached-2026.03.07

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs