### PR TITLE
Update mariadb properties from release mariadb-2026.6.2

### DIFF
--- a/module_name.txt
+++ b/module_name.txt
@@ -1,1 +1,1 @@
-git
+mariadb

--- a/modules/mariadb.properties
+++ b/modules/mariadb.properties
@@ -1,6 +1,8 @@
+12.3.2 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2026.6.2/mariadb-12.3.2-winx64.zip
 12.2.2 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2026.3.7/mariadb-12.2.2-winx64.zip
 12.1.2 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.11.22/mariadb-12.1.2-winx64.zip
 12.0.2 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2025.8.21/mariadb-12.0.2-winx64.zip
+11.8.8 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2026.6.2/mariadb-11.8.8-winx64.zip
 11.8.6 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2026.3.7/mariadb-11.8.6-winx64.zip
 11.8.5 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.11.22/mariadb-11.8.5-winx64.zip
 11.8.3 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2025.8.21/mariadb-11.8.3-winx64.zip
@@ -9,6 +11,7 @@
 11.6.1-RC = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2024.9.13/mariadb-11.6.1-winx64.zip
 11.5.2 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2024.9.13/mariadb-11.5.2-winx64.zip
 11.5.1-RC = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2024.6.25/mariadb-11.5.1-winx64.zip
+11.4.12 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2026.6.2/mariadb-11.4.12-winx64.zip
 11.4.9 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.11.22/mariadb-11.4.9-winx64.zip
 11.4.8 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2025.8.21/mariadb-11.4.8-winx64.zip
 11.4.7 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.7.2/mariadb-11.4.7-winx64.zip
@@ -29,6 +32,7 @@
 11.0.5 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2024.3.31/mariadb-11.0.5-winx64.zip
 11.0.2 = https://github.com/Bearsampp/modules-untouched/releases/download/MariaDB-2023.7.23/mariadb-11.0.2-winx64.zip
 11.0.1-RC = https://github.com/Bearsampp/modules-untouched/releases/download/MariaDB-2023.4.30/mariadb-11.0.1-rc-winx64.7z
+10.11.18 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2026.6.2/mariadb-10.11.18-winx64.zip
 10.11.15 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.11.22/mariadb-10.11.15-winx64.zip
 10.11.14 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2025.8.21/mariadb-10.11.14-winx64.zip
 10.11.13 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.7.2/mariadb-10.11.13-winx64.zip
@@ -58,6 +62,7 @@
 10.7.8 = https://github.com/Bearsampp/modules-untouched/releases/download/MariaDB-2023.4.30/mariadb-10.7.8-winx64.zip
 10.7.7 = https://github.com/Bearsampp/modules-untouched/releases/download/MariaDB-2022.12.03/mariadb-10.7.7-winx64.zip
 10.7.6 = https://github.com/Bearsampp/modules-untouched/releases/download/MariaDB-2022.10.24/mariadb-10.7.6-winx64.zip
+10.6.27 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2026.6.2/mariadb-10.6.27-winx64.zip
 10.6.24 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.11.22/mariadb-10.6.24-winx64.zip
 10.6.23 = https://github.com/Bearsampp/modules-untouched/releases/download/Mariadb-2025.8.21/mariadb-10.6.23-winx64.zip
 10.6.22 = https://github.com/Bearsampp/modules-untouched/releases/download/mariadb-2025.7.2/mariadb-10.6.22-winx64.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `mariadb.properties` file with new versions from release `mariadb-2026.6.2`.

### Changes:
- Extracted assets starting with `mariadb` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/mariadb-2026.6.2

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs