### PR TITLE
Update php properties from release php-2026.6.2

### DIFF
--- a/module_name.txt
+++ b/module_name.txt
@@ -1,1 +1,1 @@
-nodejs
+php

--- a/modules/php.properties
+++ b/modules/php.properties
@@ -1,7 +1,9 @@
+8.5.7 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.6.2/php-8.5.7-Win32-vs17-x64.zip
 8.5.5 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.4.18/php-8.5.5-Win32-vs17-x64.zip
 8.5.3 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php-8.5.3-Win32-vs17-x64.zip
 8.5.2 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php-8.5.2-Win32-vs17-x64.zip
 8.5.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php-8.5.0-Win32-vs17-x64.zip
+8.4.22 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.6.2/php-8.4.22-Win32-vs17-x64.zip
 8.4.20 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.4.18/php-8.4.20-Win32-vs17-x64.zip
 8.4.18 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php-8.4.18-Win32-vs17-x64.zip
 8.4.17 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php-8.4.17-Win32-vs17-x64.zip
@@ -15,6 +17,7 @@
 8.4.4 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.2.20/php-8.4.4-Win32-vs17-x64.zip
 8.4.3 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.2.11/php-8.4.3-Win32-vs17-x64.zip
 8.4.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2024.11.30/php-8.4.1-Win32-vs17-x64.zip
+8.3.31 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.6.2/php-8.3.31-Win32-vs16-x64.zip
 8.3.30 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php-8.3.30-Win32-vs16-x64.zip
 8.3.28 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php-8.3.28-Win32-vs16-x64.zip
 8.3.27 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.10.31/php-8.3.27-Win32-vs16-x64.zip
@@ -51,7 +54,7 @@
 8.2.3 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2023.3.5/php-8.2.3-Win32-vs16-x64.zip
 8.2.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2023.1.31/php-8.2.1-Win32-vs16-x64.zip
 8.2.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.12.13/php-8.2.0-Win32-vs16-x64.zip
-8.2 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.4.18/php_memcache-8.2-8.5-ts-vs17-x64.zip
+8.2 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.6.2/php_memcache-8.2-8.5-ts-vs17-x64.zip
 8.1.33 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.8.20/php-8.1.33-Win32-vs16-x64.zip
 8.1.32 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.4.8/php-8.1.32-Win32-vs16-x64.zip
 8.1.31 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2024.11.30/php-8.1.31-Win32-vs16-x64.zip
@@ -84,7 +87,7 @@
 7.4.32 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.09.30/php-7.4.32-Win32-vc15-x64.zip
 7.4.30 = https://github.com/Bearsampp/modules-untouched/releases/download/php-7.4.30/php-7.4.30-Win32-vc15-x64.zip
 5.6.40 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2022.07.30/php-5.6.40-Win32-VC11-x64.zip
-3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.8.1-8.5-ts-vs17-x64.zip
+3.8.1 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.6.2/php_imagick-3.8.1-8.5-ts-vs17-x64.zip
 3.8.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2025.12.7/php_imagick-3.8.0-8.5-ts-vs17-x64.zip
 3.7.0 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.7.0-8.4-ts-vs17-x64.zip
-1.22.8 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.4.18/php_zip-1.22.8-8.5-ts-vs17-x64.zip
+1.22.8 = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.6.2/php_zip-1.22.8-8.5-ts-vs17-x64.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `php.properties` file with new versions from release `php-2026.6.2`.

### Changes:
- Extracted assets starting with `php` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/php-2026.6.2

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs