### PR TITLE
Update postgresql properties from release postgresql-2026.6.2

### DIFF
--- a/module_name.txt
+++ b/module_name.txt
@@ -1,1 +1,1 @@
-php
+postgresql

--- a/modules/postgresql.properties
+++ b/modules/postgresql.properties
@@ -1,5 +1,7 @@
+18.4 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.6.2/postgresql-18.4-1-windows-x64-binaries.zip
 18.3 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.3.8/postgresql-18.3-1-windows-x64-binaries.zip
 18.1 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.11.21/postgresql-18.1-1-windows-x64-binaries.zip
+17.10 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.6.2/postgresql-17.10-1-windows-x64-binaries.zip
 17.9 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.3.8/postgresql-17.9-1-windows-x64-binaries.zip
 17.7 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.11.21/postgresql-17.7-1-windows-x64-binaries.zip
 17.5 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.7.2/postgresql-17.5-2-windows-x64-binaries.zip
@@ -7,6 +9,7 @@
 17.2.3 = https://github.com/Bearsampp/modules-untouched/releases/download/PostgreSQL-17.2.3/postgresql-17.2-3-windows-x64-binaries.zip
 17.2.1 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2024.12.1/postgresql-17.2-1-windows-x64-binaries.zip
 17.0-RC1 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2024.9.18/postgresql-17.0-rc1-windows-x64-binaries.zip
+16.14 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.6.2/postgresql-16.14-1-windows-x64-binaries.zip
 16.13 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.3.8/postgresql-16.13-1-windows-x64-binaries.zip
 16.11 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.11.21/postgresql-16.11-1-windows-x64-binaries.zip
 16.9 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.7.2/postgresql-16.9-2-windows-x64-binaries.zip
@@ -14,6 +17,7 @@
 16.4 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2024.9.18/postgresql-16.4-1-windows-x64-binaries.zip
 16.2 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2024.4.16/postgresql-16.2-1-windows-x64-binaries.zip
 16.0 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2023.10.9/postgresql-16.0-1-windows-x64-binaries.zip
+15.18 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.6.2/postgresql-15.18-1-windows-x64-binaries.zip
 15.17 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.3.8/postgresql-15.17-1-windows-x64-binaries.zip
 15.15 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.11.21/postgresql-15.15-1-windows-x64-binaries.zip
 15.13 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.7.2/postgresql-15.13-2-windows-x64-binaries.zip
@@ -23,6 +27,7 @@
 15.3 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2023.7.23/postgresql-15.3-3-windows-x64-binaries.zip
 15.2 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2023.4.20/postgresql-15.2-2-windows-x64-binaries.zip
 15.0 = https://github.com/Bearsampp/modules-untouched/releases/download/Postgresql-2022.10.28/postgresql-15.0-1-windows-x64-binaries.zip
+14.23 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.6.2/postgresql-14.23-1-windows-x64-binaries.zip
 14.22 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2026.3.8/postgresql-14.22-1-windows-x64-binaries.zip
 14.20 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.11.21/postgresql-14.20-1-windows-x64-binaries.zip
 14.18 = https://github.com/Bearsampp/modules-untouched/releases/download/postgresql-2025.7.2/postgresql-14.18-2-windows-x64-binaries.zip


### PR DESCRIPTION
## 🤖 Automated Module Properties Update

This PR updates the `postgresql.properties` file with new versions from release `postgresql-2026.6.2`.

### Changes:
- Extracted assets starting with `postgresql` (.7z, .exe, or .zip files)
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/modules-untouched/releases/tag/postgresql-2026.6.2

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs