### PR TITLE
Update python properties from release Python-2026.6.3

### DIFF
--- a/modules/python.properties
+++ b/modules/python.properties
@@ -1,3 +1,4 @@
+3.14.5 = https://github.com/Bearsampp/modules-untouched/releases/download/Python-2026.6.3/WinPython64-3.14.5.0slim.7z
 3.14.4 = https://github.com/Bearsampp/modules-untouched/releases/download/python-2026.4.12/WinPython64-3.14.4.0slim.7z
 3.14.2 = https://github.com/Bearsampp/modules-untouched/releases/download/python-2026.1.16/python-3.14.2.7z
 3.13.13 = https://github.com/Bearsampp/modules-untouched/releases/download/python-2026.4.12/WinPython64-3.13.13.0slim.7z


### PR DESCRIPTION
### **User description**
Automated update of `python.properties` from release `Python-2026.6.3`.


___

### **PR Type**
Enhancement


___

### **Description**
- Add Python 3.14.5 release to available versions

- Update module properties with new WinPython64 build

- Reference Python-2026.6.3 release artifacts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Python-2026.6.3 Release"] -- "adds version" --> B["Python 3.14.5"]
  B -- "maps to" --> C["WinPython64-3.14.5.0slim.7z"]
  C -- "stored in" --> D["python.properties"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python.properties</strong><dd><code>Add Python 3.14.5 version mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/python.properties

<ul><li>Added new entry for Python 3.14.5 pointing to <br>WinPython64-3.14.5.0slim.7z<br> <li> References Python-2026.6.3 release from Bearsampp modules-untouched <br>repository<br> <li> Maintains existing Python version entries (3.14.4, 3.14.2, 3.13.13, <br>3.13.5)</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/modules-untouched/pull/116/files#diff-80a9bea1add004bc7cd9dcd2e83fa855cb59d901d4e0b2c4e9e2bc85f3b328b2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

